### PR TITLE
Plugin Rest Favorite

### DIFF
--- a/apiki-rest-favorite/apiki-rest-favorite-route-controller.php
+++ b/apiki-rest-favorite/apiki-rest-favorite-route-controller.php
@@ -1,0 +1,166 @@
+<?php
+class Apiki_Route_Controller extends WP_REST_Controller
+{
+
+    // Here initialize our namespace and resource name.
+    public function __construct()
+    {
+        $this->namespace     = '/apikirestfavorite/v1';
+        $this->resource_name = 'posts';
+    }
+
+    // Registrando as rotas do plugin
+    public function register_routes()
+    {
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->resource_name . '/(?P<postid>[\d]+)',
+            array(
+                array(
+                    'methods'   => WP_REST_Server::CREATABLE,
+                    'callback'  => array($this, 'setPostFavorite'),
+                ),
+            )
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->resource_name . '/(?P<postid>[\d]+)'.'/(?P<userid>[\d]+)',
+            array(
+                array(
+                    'methods'   => WP_REST_Server::READABLE,
+                    'callback'  => array($this, 'getPostFavorite'),
+                ),
+            )
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->resource_name . '/(?P<postid>[\d]+)',
+            array(
+                array(
+                    'methods'   => WP_REST_Server::DELETABLE,
+                    'callback'  => array($this, 'unsetPostFavorite'),
+                ),
+            )
+        );
+    }
+
+    /**
+     * 
+     *
+     * @param WP_REST_Request $request Current request.
+     */
+    public function getPostFavorite($request)
+    {
+        $userid = (int) $request['userid'];
+        $postid = (int) $request['postid'];
+
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'favorite';
+        $data = $wpdb->get_results("SELECT * FROM $table_name WHERE post_ID= '" . $postid . "' and user_ID= '" . $userid . "' ");
+        if ($wpdb->num_rows == 0) {
+            return new WP_REST_Response(
+                array(
+                    'status' => '200',
+                    'response' => 'FALSE'
+                )
+            );
+        } else {
+            return new WP_REST_Response(
+                array(
+                    'status' => '200',
+                    'response' => 'TRUE'
+                )
+            );
+        }
+    }
+
+    /**
+     *
+     * @param WP_REST_Request $request Current request.
+     */
+    public function setPostFavorite($request)
+    {
+
+        $postid = (int) $request['postid'];
+        $userid = (int) $request['user'];
+        $parameters = $request->get_json_params();
+
+        if (wp_create_nonce('wp_rest') == $request->get_header('X-WP-Nonce') && isset($userid) && $userid <> 0) {
+
+            global $wpdb;
+            $table_name = $wpdb->prefix . 'favorite';
+            $data = $wpdb->get_results("SELECT * FROM $table_name WHERE post_ID= '" . $postid . "' and user_ID= '" . $userid . "' ");
+            if ($wpdb->num_rows == 0) {
+                $wpdb->query($wpdb->prepare("insert into " . $table_name . " (post_ID, user_ID) VALUES (" . $postid . " ," . $userid . ")"));
+                return new WP_REST_Response(
+                    array(
+                        'status' => '200',
+                        'response' => 'Post favoritado com sucesso.',
+                        'body_response' => $parameters
+                    )
+                );
+            } else {
+                return new WP_REST_Response(
+                    array(
+                        'status' => '202',
+                        'response' => 'Requisição aceita, mas não processada.',
+                        'body_response' => $parameters
+                    )
+                );
+            }
+        } else {
+            return new WP_REST_Response('Usuário não autorizado ou não logado.', '401');
+        }
+    }
+
+    /**
+     *
+     * @param WP_REST_Request $request Current request.
+     */
+    public function unsetPostFavorite($request)
+    {
+
+        $postid = (int) $request['postid'];
+        $userid = (int) $request['user'];
+        $parameters = $request->get_json_params();
+
+        if (wp_create_nonce('wp_rest') == $request->get_header('X-WP-Nonce') && isset($userid) && $userid <> 0) {
+
+            global $wpdb;
+            $table_name = $wpdb->prefix . 'favorite';
+
+            $data = $wpdb->get_results("SELECT * FROM $table_name WHERE post_ID = '" . $postid . "' and user_ID= '" . $userid . "' ");
+
+            if ($wpdb->num_rows > 0) {
+                $wpdb->query($wpdb->prepare("delete from " . $table_name . " where post_ID =" . $postid . " and user_ID =" . $userid));
+                return new WP_REST_Response(
+                    array(
+                        'status' => '200',
+                        'response' => 'Post desfavoritado com sucesso.',
+                        'body_response' => $parameters
+                    )
+                );    
+            } else {
+                return new WP_REST_Response(
+                    array(
+                        'status' => '202',
+                        'response' => 'Requisição aceita, mas não processada.',
+                        'body_response' => $parameters
+                    )
+                );
+            }
+        } else {
+            return new WP_REST_Response('Usuário não autorizado ou não logado.', '401');
+        }
+    }
+}
+
+// Function to register our new routes from the controller.
+function Apiki_REST_Favorite_Route_Controller()
+{
+    $controller = new Apiki_Route_Controller();
+    $controller->register_routes();
+}

--- a/apiki-rest-favorite/apiki-rest-favorite-script.js
+++ b/apiki-rest-favorite/apiki-rest-favorite-script.js
@@ -1,0 +1,82 @@
+$j = jQuery.noConflict();
+$j(document).ready(function () {
+
+  var namespace = "/apikirestfavorite/v1/posts/";
+  var getUrl = window.location;
+  var baseUrl =
+    getUrl.protocol +
+    "//" +
+    getUrl.host +
+    "/" +
+    getUrl.pathname.split("/")[1] +
+    "/" +
+    getUrl.pathname.split("/")[2] +
+    "/wp-json";
+
+  $j(".favoriteCheckbox").change(function () {
+
+    var postId = $j(this).val();
+
+    if ($j(this).is(":checked")) {
+      $j.ajax({
+        url: baseUrl + namespace + postId,
+        method: "POST",
+        data: JSON.stringify({
+          user : apikiScriptVars.user
+        }),
+        credentials: 'include',
+        contentType: "application/json",
+        beforeSend: function ( xhr ) {
+          xhr.setRequestHeader( 'X-WP-Nonce', apikiScriptVars.nonce );
+        },         
+        success: function (result) {
+        },
+        error: function (request, msg, error) {
+        },
+      });
+    } else {
+
+      $j.ajax({
+        url: baseUrl + namespace + postId,
+        method: "DELETE",
+        data: JSON.stringify({
+          user : apikiScriptVars.user
+        }),
+        credentials: 'include',
+        contentType: "application/json",
+        beforeSend: function ( xhr ) {
+          xhr.setRequestHeader( 'X-WP-Nonce', apikiScriptVars.nonce );
+        },         
+        success: function (result) {
+        },
+        error: function (request, msg, error) {
+        },
+      });
+    }
+  });
+
+  $j(".favoriteCheckbox").each(function() {
+
+    addEventListener("load",  () => {
+
+      var postId = $j(this).val();
+      var element = this;
+
+      $j.ajax({
+        url: baseUrl + namespace + postId + '/' +apikiScriptVars.user,
+        method: "GET",
+        credentials: 'include',
+        beforeSend: function ( xhr ) {
+          xhr.setRequestHeader( 'X-WP-Nonce', apikiScriptVars.nonce );
+        },         
+        success: function (result) {
+          if (result.response == 'TRUE') {
+            document.getElementById(element.id).setAttribute("checked", '');
+          }
+        },
+        error: function (request, msg, error) {
+        },
+      });
+    });
+  });
+})

--- a/apiki-rest-favorite/apiki-rest-favorite.php
+++ b/apiki-rest-favorite/apiki-rest-favorite.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @package apiki-rest-favorite
+ */
+/*
+Plugin Name: Apiki REST Favorite
+Plugin URI: http://apiki.com
+Description: Plugin para favoritar posts usando REST API
+Version: 1.0
+Author: Werner Max Bohling
+Author URI: http://apikki.com
+License: GPLv2 or later
+Text Domain: apiki
+*/
+
+/*
+Apiki REST Favorite is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+any later version.
+
+Apiki REST Favorite is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Apiki REST Favorite.
+*/
+
+// Não mostrar informações se chamado diretamente
+if ( !function_exists( 'add_action' ) ) {
+    exit;
+}
+
+define( 'FAVORITE_VERSION', '1.0' );
+define( 'FAVORITE__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+
+if (! class_exists('ApikiRESTFavorite')) {
+
+    class ApikiRESTFavorite {
+
+        private static $instance;
+
+        private function __construct() {
+            register_activation_hook( __FILE__, array($this, 'apiki_rest_favorite_activation'));
+            register_deactivation_hook( __FILE__, array($this, 'apiki_rest_favorite_deactivation'));
+            register_uninstall_hook( __FILE__, array($this, 'apiki_rest_favorite_uninstall'));
+        }
+
+        /**
+         * If an instance exists, this returns it.  If not, it creates one and
+         * retuns it.
+         *
+         * @return self
+         */
+        public static function getInstance() {
+            if ( !self::$instance )
+                  self::$instance = new self;
+            return self::$instance;
+        }
+
+        /**
+         * Activate the plugin.
+         */
+        public static function apiki_rest_favorite_activation() {
+            // cria a tabela para colocar os posts favoritados 
+            global $wpdb;
+            $table_name = $wpdb->prefix . "favorite"; 
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_name (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            post_ID bigint(20) NOT NULL,
+            user_ID bigint(20) NOT NULL,
+            PRIMARY KEY  (id)) $charset_collate;";
+            require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+            dbDelta( $sql );
+        }
+
+        /**
+         * Deactivate the plugin.
+         */
+        public static function apiki_rest_favorite_deactivation() { 
+        }
+
+        /**
+         * Uninstall the plugin.
+         */
+        public static function apiki_rest_favorite_uninstall() {
+            // dropa a tabela que contem os posts favoritados
+            global $wpdb;
+            $table_name = $wpdb->prefix. "favorite";
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "DROP TABLE IF EXISTS $table_name";
+            $wpdb->query($sql);
+        }
+
+        /**
+         * init
+         *
+         * @return void
+         */
+        public static function init() {
+
+            add_action('admin_enqueue_scripts', 'favorite_script');
+            function favorite_script() {
+                wp_register_script( 
+                    'apiki-favorite-jquery-script',
+                    plugins_url( '/apiki-rest-favorite-script.js', __FILE__ ), 
+                    array( 'wp-api', 'jquery' )
+                 );                   
+                wp_enqueue_script( 'apiki-favorite-jquery-script', true );
+
+                wp_localize_script( 'apiki-favorite-jquery-script', 'apikiScriptVars', [
+                    'user' => get_current_user_id(),
+                    'nonce' => wp_create_nonce('wp_rest'),
+                ] );
+            }    
+            
+            /* Add custom column to post list */
+            function add_custom_column( $columns ) {
+                return array_merge( $columns, 
+                    array( 'sticky' => 'Favorito' ) );
+            }
+            add_filter( 'manage_posts_columns' , 'add_custom_column' );
+
+            function favorite_custom_column ( $column, $post_id ) {
+                echo "<input type='checkbox'
+                    class='favoriteCheckbox'
+                    id='{$post_id}'
+                    value='{$post_id}'>";                    
+            }
+            add_action ( 'manage_posts_custom_column', 'favorite_custom_column', 10, 2 );
+
+            require_once( FAVORITE__PLUGIN_DIR . 'apiki-rest-favorite-route-controller.php' );
+            add_action( 'rest_api_init', 'Apiki_REST_Favorite_Route_Controller' );
+
+        }
+    }
+
+    // Instantiate our class
+    $plugin = ApikiRESTFavorite::getInstance();
+    $plugin::init();
+
+}
+?>


### PR DESCRIPTION
Prezado(a),

   Segue plugin para favoritar e desfavoritar um Post. 
   Criei o plugin com apenas 3 arquivos para facilitar a compreensão. São eles:
1) apiki-rest-favorite.php
Classe onde no construtor criamos e excluímos a tabela [prefixo]-favorite. A tabela é simples e contem o postID e o userID, alem da sua própria chave.

![WhatsApp Image 2022-09-15 at 14 35 19](https://user-images.githubusercontent.com/64937130/190472572-75f6acdc-8668-4c46-8f0c-ebca18a0d5f1.jpeg)

 Na classe, também inicializamos os actions e os filters. Para a interface cliente, inseri na lista de Posts um checkbox para favoritar.

![WhatsApp Image 2022-09-15 at 14 39 58](https://user-images.githubusercontent.com/64937130/190473354-1d93f5c3-52c9-4e44-b201-c19e597ed9ba.jpeg)

2) apiki-rest-favorite-script.js é onde o Jquery escuta os eventos do checkbox, e gera a chamada REST (Get, Post, Delete) para as rotas, passando o nonce no cabeçalho e o usuário por JSON.

3) apiki-rest-favorite-route-controller.js Classe que define o namespace, registra as 3 rotas.
3.1) GET tem a rota /apikirestfavorite/v1/posts/postid/userid 
3.2) POST e DELETE tem a rota /apikirestfavorite/v1/posts/postid, ambas com controle do usuário por nonce

Caso tente fazer a chamada por um cliente REST (insomnia, postman...) é gerado um status 401 - usuário não autorizado ou não logado.

Como a especificação do desafio era um tanto abrangente, penso que esse plugin atender a prova de conceito e funcionalidade dentro do que foi proposto.

Att,
Werner Max