### PR TITLE
Implementação da funcionalidade de favoritar posts

### DIFF
--- a/desafiowordpress.php
+++ b/desafiowordpress.php
@@ -1,0 +1,93 @@
+<?php
+/*
+Plugin Name: Favorite Posts
+Description: Plugin que permite que usuários logados favoritem e desfavoritem posts usando a WP REST API.
+Version: 1.0
+Author: Luan Menezes Barros 
+*/
+
+// Impedir acesso direto ao arquivo
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Executa a função ao ativar o plugin
+register_activation_hook(_FILE_, 'fp_create_favorite_table');
+
+function fp_create_favorite_table()
+{
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'favorite_posts';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+        user_id BIGINT(20) UNSIGNED NOT NULL,
+        post_id BIGINT(20) UNSIGNED NOT NULL,
+        PRIMARY KEY  (id),
+        UNIQUE KEY user_post (user_id, post_id)
+    ) $charset_collate;";
+
+    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+    dbDelta($sql);
+}
+
+// Adiciona a ação de inicializar as rotas da REST API
+add_action('rest_api_init', function () {
+    register_rest_route('favorite-posts/v1', '/toggle-favorite/(?P<post_id>\d+)', [
+        'methods' => 'POST',
+        'callback' => 'fp_toggle_favorite',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ]);
+
+    register_rest_route('favorite-posts/v1', '/list-favorites', [
+        'methods' => 'GET',
+        'callback' => 'fp_list_favorites',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ]);
+});
+
+// Função para favoritar ou desfavoritar um post
+function fp_toggle_favorite($data)
+{
+    global $wpdb;
+    $user_id = get_current_user_id();
+    $post_id = absint($data['post_id']);
+    $table_name = $wpdb->prefix . 'favorite_posts';
+
+    // Verifica se o post já está favoritado pelo usuário
+    $is_favorited = $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM $table_name WHERE user_id = %d AND post_id = %d",
+        $user_id,
+        $post_id
+    ));
+
+    if ($is_favorited) {
+        // Desfavorita o post
+        $wpdb->delete($table_name, ['user_id' => $user_id, 'post_id' => $post_id]);
+        return new WP_REST_Response(['status' => 'unfavorited'], 200);
+    } else {
+        // Favorita o post
+        $wpdb->insert($table_name, ['user_id' => $user_id, 'post_id' => $post_id]);
+        return new WP_REST_Response(['status' => 'favorited'], 200);
+    }
+}
+
+// Função para listar os favoritos do usuário atual
+function fp_list_favorites()
+{
+    global $wpdb;
+    $user_id = get_current_user_id();
+    $table_name = $wpdb->prefix . 'favorite_posts';
+
+    $favorites = $wpdb->get_results($wpdb->prepare(
+        "SELECT post_id FROM $table_name WHERE user_id = %d",
+        $user_id
+    ), ARRAY_A);
+
+    return new WP_REST_Response.(['favorites' => $favorites], 200);
+}


### PR DESCRIPTION
Descrição do Pull Request
Implementação do Plugin de Favoritos para WordPress

Este Pull Request implementa um plugin para WordPress que permite aos usuários logados favoritar e desfavoritar posts usando a WP REST API. A seguir estão os principais detalhes sobre a implementação:

Funcionalidades Implementadas
Favoritar/Desfavoritar Posts:

Usuários logados podem favoritar e desfavoritar posts através de um endpoint específico da API REST do WordPress.
A ação é realizada por meio do endpoint POST /wp-json/favorite-posts/v1/toggle-favorite/{post_id}, onde {post_id} é o ID do post a ser favoritado ou desfavoritado.
Persistência de Dados:

Os dados de favoritos são armazenados em uma tabela personalizada (wp_favorite_posts) criada no banco de dados durante a ativação do plugin.
A tabela registra o ID do usuário e o ID do post, garantindo a unicidade da combinação de ambos.
Listar Favoritos:

Usuários logados podem listar todos os seus posts favoritados através do endpoint GET /wp-json/favorite-posts/v1/list-favorites.
O endpoint retorna uma lista dos IDs dos posts favoritados pelo usuário.
Segurança:

Apenas usuários autenticados podem favoritar/desfavoritar posts ou listar seus favoritos, garantindo que as operações sejam realizadas de forma segura.
Ajustes e Melhorias Futuras
Melhorar a interface do usuário para exibir os favoritos diretamente no front-end.
Adicionar tratamento de erros mais robusto e mensagens de feedback para o usuário.
Implementar testes automatizados para garantir a qualidade do código e evitar regressões.
Como Testar
Instale e ative o plugin no WordPress.
Use os endpoints da API REST para favoritar/desfavoritar posts e listar seus favoritos.
Este plugin expande a experiência do usuário ao permitir o gerenciamento personalizado de posts favoritos, facilitando o acesso a conteúdos de interesse.