### PR TITLE
Desafio Apiki - Plugin de favoritos via REST API

### DIFF
--- a/wp-post-favorites/includes/FavoriteController.php
+++ b/wp-post-favorites/includes/FavoriteController.php
@@ -1,0 +1,45 @@
+<?php
+
+class FavoriteController {
+    // Método para favoritar ou desfavoritar um post
+    public static function toggle($request) {
+        global $wpdb;
+
+        $user_id = get_current_user_id();
+        $post_id = $request->get_param('post_id');
+        $table = $wpdb->prefix . 'post_favorites';
+
+        // Verifica se o post já está favoritado pelo usuário
+        $exists = $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM $table WHERE user_id = %d AND post_id = %d",
+            $user_id,
+            $post_id
+        ));
+
+        if ($exists) {
+            // Se já existe, remove (desfavorita)
+            $wpdb->delete($table, ['user_id' => $user_id, 'post_id' => $post_id]);
+            return ['status' => 'removed'];
+        } else {
+            // Se não existe, insere (favorita)
+            $wpdb->insert($table, ['user_id' => $user_id, 'post_id' => $post_id]);
+            return ['status' => 'added'];
+        }
+    }
+
+    // Método para listar os posts favoritados pelo usuário logado
+    public static function list($request) {
+        global $wpdb;
+
+        $user_id = get_current_user_id();
+        $table = $wpdb->prefix . 'post_favorites';
+
+        // Busca todos os IDs dos posts favoritados pelo usuário
+        $favorites = $wpdb->get_col($wpdb->prepare(
+            "SELECT post_id FROM $table WHERE user_id = %d",
+            $user_id
+        ));
+
+        return $favorites;
+    }
+}

--- a/wp-post-favorites/includes/Install.php
+++ b/wp-post-favorites/includes/Install.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Classe responsável por instalar o plugin
+ * Cria a tabela wp_post_favorites no banco de dados
+ */
+class Install {
+    public static function run() {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'post_favorites';
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE $table_name (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            post_id BIGINT UNSIGNED NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_post (user_id, post_id)
+        ) $charset_collate;";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+}

--- a/wp-post-favorites/includes/Routes.php
+++ b/wp-post-favorites/includes/Routes.php
@@ -1,0 +1,29 @@
+<?php
+
+class Routes {
+    public static function register() {
+        // Rota para favoritar/desfavoritar post
+        register_rest_route('post-favorites/v1', '/toggle', [
+            'methods' => 'POST',
+            'callback' => ['FavoriteController', 'toggle'],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+            'args' => [
+                'post_id' => [
+                    'required' => true,
+                    'type' => 'integer',
+                ]
+            ]
+        ]); 
+        
+        // Rota para listar favoritos do usuário logado
+        register_rest_route('post-favorites/v1', '/list', [
+            'methods' => 'GET',
+            'callback' => ['FavoriteController', 'list'],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            }
+        ]);
+    }
+}

--- a/wp-post-favorites/post-favorites.php
+++ b/wp-post-favorites/post-favorites.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: Post Favorites
+ * Description: Permite que usuários logados favoritem posts via REST API.
+ * Version: 1.0
+ * Author: Gustavo Almeida
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Inclui funcionalidades do plugin
+require_once plugin_dir_path(__FILE__) . 'includes/Install.php';
+require_once plugin_dir_path(__FILE__) . 'includes/Routes.php';
+require_once plugin_dir_path(__FILE__) . 'includes/FavoriteController.php';
+
+// Ativa o plugin e cria a tabela
+function pf_create_favorites_table() {
+    Install::run();
+}
+register_activation_hook(__FILE__, 'pf_create_favorites_table');
+
+// Registra as rotas da REST API
+add_action('rest_api_init', ['Routes', 'register']);


### PR DESCRIPTION
Olá! Segue a entrega do desafio técnico para a vaga de Back-end WordPress na Apiki.

✅ Plugin para favoritar e desfavoritar posts via WP REST API
✅ Acesso restrito a usuários logados (com verificação via permission_callback)
✅ Dados persistidos em uma tabela separada no banco de dados
✅ Implementação orientada a objetos com separação clara por responsabilidades:
- Install.php → cria a tabela personalizada na ativação do plugin
- Routes.php → registra os endpoints REST
- FavoriteController.php → trata as ações de toggle e listagem
✅ Testado em ambiente local com autenticação JWT funcionando corretamente

Obrigado pela oportunidade!  
Feito com carinho por: **Gustavo Almeida**