### PR TITLE
Lucas Marques — WordPress back-end challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/vendor/
+.phpunit.result.cache
+.phpunit.cache/
+*.log
+.DS_Store
+/composer.lock

--- a/README.md
+++ b/README.md
@@ -1,27 +1,134 @@
-# WordPress Back-end Challenge
+# Apiki Favorites
 
-Desafio para os futuros programadores back-end em WordPress da Apiki.
+Plugin WordPress que permite a usuários logados favoritar e desfavoritar posts via WP REST API. Os dados são persistidos em uma tabela própria do plugin.
 
-## Introdução
+## Spec atendida
 
-Desenvolva um Plugin em WordPress que implemente a funcionalidade de favoritar posts para usuários logados usando a [WP REST API](https://developer.wordpress.org/rest-api/).
+- ✅ Favoritar um post
+- ✅ Desfavoritar um post
+- ✅ Listar favoritos do usuário atual (extra, útil para o consumidor da API)
+- ✅ Persistência em **tabela própria** (não usa `user_meta` nem `post_meta`)
+- ✅ Acessível apenas a usuários logados
+- ✅ Orientado a objetos
 
-**Especifícações**:
+## Endpoints
 
-* Possibilidade de favoritar e desfavoritar um post;
-* Persistir os dados em uma [tabela a parte](https://codex.wordpress.org/Creating_Tables_with_Plugins);
+Todos abaixo `/wp-json/apiki-favorites/v1`. Autenticação por cookie + nonce do WordPress (`X-WP-Nonce` header) ou Application Password.
 
-## Instruções
+| Método HTTP | URL | Descrição | Status sucesso |
+|---|---|---|---|
+| `GET` | `/favorites?page=1&per_page=10` | Lista favoritos paginados do usuário atual | `200` |
+| `POST` | `/favorites` body `{"post_id": 123}` | Favorita um post | `201` |
+| `DELETE` | `/favorites/{post_id}` | Desfavorita um post | `204` |
 
-1. Efetue o fork deste repositório e crie um branch com o seu nome e sobrenome. (exemplo: fulano-dasilva)
-2. Após finalizar o desafio, crie um Pull Request.
-3. Aguarde algum contribuidor realizar o code review.
+Erros padronizados via `WP_Error`:
 
-## Pré-requisitos
+| Código | Quando | Erro |
+|---|---|---|
+| `401` | Usuário não autenticado | `rest_forbidden_context` |
+| `403` | Usuário sem capability `read` | `rest_forbidden` |
+| `404` | Post inexistente ou não publicado / favorito inexistente | `rest_post_invalid` / `rest_favorite_not_found` |
+| `409` | Post já está nos favoritos | `rest_already_favorited` |
 
-* PHP >= 5.6
-* Orientado a objetos
+### Exemplos com `curl`
 
-## Dúvidas
+```bash
+# Favoritar (precisa de cookie de login + nonce)
+curl -X POST http://localhost:8080/wp-json/apiki-favorites/v1/favorites \
+  -H "Content-Type: application/json" \
+  -H "X-WP-Nonce: $NONCE" \
+  --cookie "$COOKIE" \
+  -d '{"post_id": 123}'
 
-Em caso de dúvidas, crie uma issue.
+# Listar
+curl http://localhost:8080/wp-json/apiki-favorites/v1/favorites \
+  -H "X-WP-Nonce: $NONCE" --cookie "$COOKIE"
+
+# Desfavoritar
+curl -X DELETE http://localhost:8080/wp-json/apiki-favorites/v1/favorites/123 \
+  -H "X-WP-Nonce: $NONCE" --cookie "$COOKIE"
+```
+
+Em desenvolvimento, a forma mais simples de testar é gerar uma **Application Password** no perfil do usuário do wp-admin e usar Basic Auth:
+
+```bash
+curl -u "usuario:senha-app-aqui" \
+  http://localhost:8080/wp-json/apiki-favorites/v1/favorites
+```
+
+## Como rodar localmente (Docker)
+
+```bash
+docker compose up -d
+# Acesse http://localhost:8080 e finalize o setup do WordPress.
+# Depois, em Plugins, ative o "Apiki Favorites".
+
+# Instalar dependências do plugin (PHPCS):
+docker compose run --rm cli install
+
+# Rodar lint (WordPress Coding Standards):
+docker compose run --rm cli lint
+```
+
+## Estrutura do projeto
+
+```
+apiki-favorites/
+├── apiki-favorites.php              # Plugin header + bootstrap (entry point)
+├── uninstall.php                    # Limpa a tabela quando o plugin é DESINSTALADO (não no deactivate)
+├── composer.json                    # PSR-4 + WPCS lint
+├── phpcs.xml.dist                   # WordPress Coding Standards
+├── docker-compose.yml               # WP 6.6 + PHP 8.1 + MySQL 8
+└── src/
+    ├── Plugin.php                   # Composition root — registra hooks
+    ├── Activator.php                # Cria a tabela via dbDelta
+    ├── Domain/
+    │   ├── Favorite.php             # Value object readonly
+    │   └── FavoriteException.php    # Exception de domínio, carrega o HTTP code
+    ├── Repository/
+    │   └── FavoritesRepository.php  # CRUD; recebe wpdb via DI no construtor
+    └── REST/
+        └── FavoritesController.php  # extends WP_REST_Controller
+```
+
+## Tabela
+
+```sql
+CREATE TABLE wp_apiki_favorites (
+    id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id BIGINT(20) UNSIGNED NOT NULL,
+    post_id BIGINT(20) UNSIGNED NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY user_post (user_id, post_id),
+    KEY user_id (user_id),
+    KEY post_id (post_id)
+);
+```
+
+Decisões:
+
+- **Tabela própria** em vez de `user_meta` — a spec pede explicitamente, e queries do tipo "quem favoritou o post X?" ou "quais posts o usuário Y favoritou?" são `O(N)` em meta tables (full scan), mas `O(log N)` aqui graças aos índices.
+- **`UNIQUE (user_id, post_id)`** — impede duplicação no nível do banco. Mesmo se a aplicação esquecer de checar antes do INSERT, o MySQL rejeita a linha.
+- **`dbDelta`** no activation hook — padrão do WordPress, lida com ALTER TABLE em upgrades futuros sem perder dados.
+
+## Decisões de design
+
+| Decisão | Por quê |
+|---|---|
+| **`final class` em tudo** | Fecha o contrato. Se alguém quiser variar comportamento, compõe — não herda. |
+| **Sem Singleton** | `Plugin::boot()` é um *composition root* sem estado mutável. WordPress já garante que o arquivo é carregado uma única vez por request. |
+| **`global $wpdb` lido apenas no `Plugin::boot()`** | O `FavoritesRepository` recebe `wpdb` via construtor e o guarda em property `readonly`. Nenhum método chama `global $wpdb` — facilita teste, deixa a dependência explícita. |
+| **Value Object `Favorite` com properties `readonly`** | Mesma motivação do `ExchangeInput` do back-end PHP: o objeto que sai do repositório não pode ser modificado por engano. |
+| **`extends WP_REST_Controller`** em vez de chamar `register_rest_route()` no nada | Herda os helpers de schema, `prepare_response_for_collection`, `add_additional_fields_schema`, etc. |
+| **`WP_REST_Server::READABLE / CREATABLE / DELETABLE`** em vez de strings `'GET'/'POST'/'DELETE'` | Constantes são bitmask-friendly, documentadas, e qualquer mudança no core do WP é refletida automaticamente. |
+| **`current_user_can('read')` em vez de só `is_user_logged_in()`** | Routear a autorização pelo sistema de capabilities permite que um admin (com um plugin de roles, por exemplo) restrinja o acesso sem mexer no código. `is_user_logged_in()` apenas responde "tem usuário?" — `current_user_can()` responde "ele PODE fazer isso?". |
+| **`defined('ABSPATH') \|\| exit;` no topo de todos os `.php`** | Defesa: se alguém acessar o arquivo direto via URL (configuração errada de servidor), o script aborta em vez de vazar caminho/código. |
+| **`uninstall.php` separado** | WordPress chama esse arquivo só no *uninstall* (DELETE), não no *deactivate*. A tabela só some quando o usuário REALMENTE remove o plugin. |
+| **Exception de domínio** (`FavoriteException`) | Carrega o HTTP code (`409`, `404`) em `getCode()` — o controller mapeia direto pra `WP_Error` sem inspecionar mensagem. |
+
+## Requisitos
+
+- WordPress 6.0+
+- PHP 8.1+ (uso de `readonly` properties e constructor property promotion)
+- MySQL 5.7+ / MariaDB 10.3+

--- a/apiki-favorites.php
+++ b/apiki-favorites.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Plugin Name:       Apiki Favorites
+ * Plugin URI:        https://github.com/apiki/wordpress-back-end-challenge
+ * Description:       Allows logged-in users to favorite and unfavorite posts through the WP REST API. Data is persisted in a custom database table.
+ * Version:           1.0.0
+ * Requires at least: 6.0
+ * Requires PHP:      8.1
+ * Author:            Seu Nome
+ * License:           MIT
+ * Text Domain:       apiki-favorites
+ *
+ * @package Apiki\Favorites
+ */
+
+declare(strict_types=1);
+
+defined('ABSPATH') || exit;
+
+/**
+ * Hard fail (with admin notice) if the PHP version is below the minimum
+ * required. We use readonly properties and constructor property promotion,
+ * which require PHP 8.1+. Activating on an older runtime would result in
+ * a fatal parse error elsewhere, so we stop early and tell the user.
+ */
+if (PHP_VERSION_ID < 80100) {
+    add_action('admin_notices', static function (): void {
+        $message = sprintf(
+            /* translators: %s is the current PHP version */
+            esc_html__('Apiki Favorites requires PHP 8.1 or higher. You are running PHP %s.', 'apiki-favorites'),
+            esc_html(PHP_VERSION)
+        );
+        printf('<div class="notice notice-error"><p>%s</p></div>', $message);
+    });
+    return;
+}
+
+if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+    add_action('admin_notices', static function (): void {
+        printf(
+            '<div class="notice notice-error"><p>%s</p></div>',
+            esc_html__('Apiki Favorites: run "composer install" in the plugin directory.', 'apiki-favorites')
+        );
+    });
+    return;
+}
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Apiki\Favorites\Activator;
+use Apiki\Favorites\Plugin;
+
+register_activation_hook(__FILE__, [Activator::class, 'activate']);
+
+Plugin::boot();

--- a/apiki-favorites.php
+++ b/apiki-favorites.php
@@ -31,12 +31,16 @@ if (PHP_VERSION_ID < 80100) {
             esc_html__('Apiki Favorites requires PHP 8.1 or higher. You are running PHP %s.', 'apiki-favorites'),
             esc_html(PHP_VERSION)
         );
-        printf('<div class="notice notice-error"><p>%s</p></div>', $message);
+        printf(
+            '<div class="notice notice-error"><p>%s</p></div>',
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $message already built with esc_html__() above.
+            $message
+        );
     });
     return;
 }
 
-if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+if ( ! file_exists(__DIR__ . '/vendor/autoload.php')) {
     add_action('admin_notices', static function (): void {
         printf(
             '<div class="notice notice-error"><p>%s</p></div>',

--- a/apiki-favorites.php
+++ b/apiki-favorites.php
@@ -7,7 +7,7 @@
  * Version:           1.0.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
- * Author:            Seu Nome
+ * Author:            Lucas Marques
  * License:           MIT
  * Text Domain:       apiki-favorites
  *

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "apiki/favorites",
+    "description": "WordPress plugin that lets logged-in users favorite posts via REST API.",
+    "type": "wordpress-plugin",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "squizlabs/php_codesniffer": "^3.7",
+        "wp-coding-standards/wpcs": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Apiki\\Favorites\\": "src/"
+        }
+    },
+    "scripts": {
+        "lint": "./vendor/bin/phpcs",
+        "lint:fix": "./vendor/bin/phpcbf"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  wordpress:
+    image: wordpress:6.6-php8.1-apache
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wp
+      WORDPRESS_DB_PASSWORD: wp
+      WORDPRESS_DB_NAME: wp
+      WORDPRESS_DEBUG: 1
+      WORDPRESS_CONFIG_EXTRA: |
+        define('WP_DEBUG_LOG', true);
+        define('WP_DEBUG_DISPLAY', false);
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - wp_data:/var/www/html
+      # The plugin folder is mounted into the wp-content/plugins directory.
+      # Changes on the host are visible immediately inside the container.
+      - ./:/var/www/html/wp-content/plugins/apiki-favorites
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wp
+      MYSQL_USER: wp
+      MYSQL_PASSWORD: wp
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # CLI service for running composer / phpcs without polluting the host.
+  # Usage:
+  #   docker compose run --rm cli install
+  #   docker compose run --rm cli lint
+  cli:
+    image: composer:2
+    working_dir: /app
+    volumes:
+      - ./:/app
+    entrypoint: ["composer"]
+    command: ["--version"]
+
+volumes:
+  wp_data:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       WORDPRESS_CONFIG_EXTRA: |
         define('WP_DEBUG_LOG', true);
         define('WP_DEBUG_DISPLAY', false);
+        define('WP_ENVIRONMENT_TYPE', 'local');
     depends_on:
       db:
         condition: service_healthy

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<ruleset name="Apiki Favorites">
+    <description>Coding standards for the Apiki Favorites plugin.</description>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg value="sp"/>
+
+    <file>apiki-favorites.php</file>
+    <file>uninstall.php</file>
+    <file>src</file>
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/tests/*</exclude-pattern>
+
+    <rule ref="WordPress">
+        <!-- We use PSR-4 + namespaces, not WP underscore_file_names. -->
+        <exclude name="WordPress.Files.FileName"/>
+        <!-- Yoda conditions are a stylistic choice we don't enforce. -->
+        <exclude name="WordPress.PHP.YodaConditions"/>
+    </rule>
+
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array" value="apiki-favorites"/>
+        </properties>
+    </rule>
+
+    <config name="minimum_supported_wp_version" value="6.0"/>
+
+    <rule ref="PHPCompatibilityWP"/>
+    <config name="testVersion" value="8.1-"/>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,16 +14,57 @@
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*/tests/*</exclude-pattern>
 
+    <!--
+        We adopt WordPress security/i18n/db rules but opt out of cosmetic
+        rules that conflict with modern PSR-12-style PHP 8.1: tabs-over-
+        spaces, array() over [], brace placement, alignment, and PHPDoc
+        requirements that don't add value for self-evident typed code.
+    -->
     <rule ref="WordPress">
-        <!-- We use PSR-4 + namespaces, not WP underscore_file_names. -->
+        <!-- PSR-4 namespaces: file names follow class names, not snake_case. -->
         <exclude name="WordPress.Files.FileName"/>
-        <!-- Yoda conditions are a stylistic choice we don't enforce. -->
+
+        <!-- Yoda conditions: stylistic choice we don't enforce. -->
         <exclude name="WordPress.PHP.YodaConditions"/>
+
+        <!-- Short array syntax is fine in 2026; WP core itself uses it now. -->
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
+        <!-- Indentation: we use 4 spaces (PSR-12), not tabs. -->
+        <exclude name="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+        <!-- Brace placement: PSR-12 puts function brace on next line. -->
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
+        <exclude name="Generic.Classes.OpeningBraceSameLine"/>
+
+        <!-- Function call spacing: PSR-12 doesn't put space inside parens. -->
+        <exclude name="PEAR.Functions.FunctionCallSignature"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+        <exclude name="NormalizedArrays.Arrays.ArrayBraceSpacing"/>
+
+        <!-- Array alignment: not worth the churn for small assoc arrays. -->
+        <exclude name="WordPress.Arrays.MultipleStatementAlignment"/>
+        <exclude name="WordPress.Arrays.ArrayIndentation"/>
+        <exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
+
+        <!-- PHPDoc: our methods are typed and self-documenting. -->
+        <exclude name="Squiz.Commenting.FileComment"/>
+        <exclude name="Squiz.Commenting.FunctionComment"/>
+        <exclude name="Squiz.Commenting.ClassComment"/>
+        <exclude name="Squiz.Commenting.VariableComment"/>
+        <exclude name="Generic.Commenting.DocComment"/>
+
+        <!-- Inline control structures: we never use them anyway. -->
+        <exclude name="Generic.ControlStructures.InlineControlStructure"/>
     </rule>
 
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" type="array" value="apiki-favorites"/>
+            <property name="text_domain" type="array">
+                <element value="apiki-favorites"/>
+            </property>
         </properties>
     </rule>
 

--- a/src/Activator.php
+++ b/src/Activator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Plugin activation handler.
+ *
+ * Creates the custom table used to persist favorites. We deliberately use
+ * a dedicated table (not user_meta or post_meta) because the spec asks for
+ * persistence in "uma tabela a parte" and because user/post meta would
+ * require expensive full-table scans to answer "which posts has user X
+ * favorited?" or "how many users favorited post Y?".
+ */
+final class Activator
+{
+    public static function activate(): void
+    {
+        global $wpdb;
+
+        $table           = Plugin::table_name($wpdb);
+        $charset_collate = $wpdb->get_charset_collate();
+
+        // Composite UNIQUE on (user_id, post_id) prevents duplicate
+        // favorites at the DATABASE level — even if a race condition
+        // bypasses the application-level check, the DB rejects the row.
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT(20) UNSIGNED NOT NULL,
+            post_id BIGINT(20) UNSIGNED NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY user_post (user_id, post_id),
+            KEY user_id (user_id),
+            KEY post_id (post_id)
+        ) {$charset_collate};";
+
+        // dbDelta is the WordPress-blessed way to run schema changes.
+        // On first install it creates the table; on subsequent plugin
+        // updates, if the CREATE TABLE statement above changes, dbDelta
+        // generates the appropriate ALTER TABLE without losing data.
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+}

--- a/src/Domain/Favorite.php
+++ b/src/Domain/Favorite.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites\Domain;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Immutable value object representing a single favorite record.
+ *
+ * Readonly properties guarantee that once a Favorite is built — typically
+ * by the repository when reading from the DB — nothing further down the
+ * call stack can mutate it. The same pattern used in the back-end PHP
+ * challenge (ExchangeInput): a typed VO is safer to pass between layers
+ * than a loose associative array.
+ */
+final class Favorite
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly int $user_id,
+        public readonly int $post_id,
+        public readonly string $created_at,
+    ) {
+    }
+
+    /**
+     * Builds a Favorite from a $wpdb row (object or assoc array).
+     *
+     * Centralizes the row-to-object conversion in one place — the
+     * repository never has to remember the column names individually.
+     *
+     * @param object|array<string, mixed> $row
+     */
+    public static function from_row(object|array $row): self
+    {
+        $data = (array) $row;
+
+        return new self(
+            (int) $data['id'],
+            (int) $data['user_id'],
+            (int) $data['post_id'],
+            (string) $data['created_at'],
+        );
+    }
+
+    /**
+     * Returns the public REST representation.
+     *
+     * @return array{id: int, user_id: int, post_id: int, created_at: string}
+     */
+    public function to_array(): array
+    {
+        return [
+            'id'         => $this->id,
+            'user_id'    => $this->user_id,
+            'post_id'    => $this->post_id,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/src/Domain/FavoriteException.php
+++ b/src/Domain/FavoriteException.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites\Domain;
+
+use RuntimeException;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Domain-specific exception for favorite-related business rule violations.
+ *
+ * Carries the appropriate HTTP status code in getCode(), so the REST
+ * controller can map it directly to a WP_Error response without having
+ * to inspect the message.
+ *
+ * Using a dedicated exception class (rather than a generic RuntimeException)
+ * lets the controller `catch (FavoriteException $e)` and trust that it's
+ * a known business case — never accidentally swallowing an unrelated
+ * runtime error.
+ */
+final class FavoriteException extends RuntimeException
+{
+    public static function already_exists(int $user_id, int $post_id): self
+    {
+        return new self(
+            sprintf('User %d has already favorited post %d.', $user_id, $post_id),
+            409
+        );
+    }
+
+    public static function not_found(int $user_id, int $post_id): self
+    {
+        return new self(
+            sprintf('Favorite not found for user %d on post %d.', $user_id, $post_id),
+            404
+        );
+    }
+
+    public static function post_not_published(int $post_id): self
+    {
+        return new self(
+            sprintf('Post %d does not exist or is not published.', $post_id),
+            404
+        );
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites;
+
+use Apiki\Favorites\Repository\FavoritesRepository;
+use Apiki\Favorites\REST\FavoritesController;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Plugin bootstrap.
+ *
+ * This is intentionally NOT a Singleton. There's no mutable state to
+ * protect — Plugin::boot() is just a stateless composition root that
+ * wires dependencies together at the right WordPress lifecycle hook.
+ *
+ * Singletons in plugins create global state that is hard to mock in tests
+ * and impossible to swap at runtime. The equivalent goal (one initialization
+ * per request) is already guaranteed by WordPress: this file is loaded once
+ * via the plugin loader, and hooks are registered exactly once.
+ */
+final class Plugin
+{
+    public const VERSION         = '1.0.0';
+    public const REST_NAMESPACE  = 'apiki-favorites/v1';
+    public const TABLE_NAME      = 'apiki_favorites';
+    public const TEXT_DOMAIN     = 'apiki-favorites';
+
+    /**
+     * Wires the plugin into WordPress.
+     *
+     * `global $wpdb` is read exactly ONE TIME, here at the composition root.
+     * Every collaborator that needs database access receives the same
+     * instance via constructor injection — no repository, controller, or
+     * service ever calls `global $wpdb` itself.
+     */
+    public static function boot(): void
+    {
+        add_action('rest_api_init', static function (): void {
+            global $wpdb;
+
+            $repository = new FavoritesRepository(
+                $wpdb,
+                $wpdb->prefix . self::TABLE_NAME
+            );
+
+            $controller = new FavoritesController($repository);
+            $controller->register_routes();
+        });
+    }
+
+    /**
+     * Returns the full table name (with WordPress prefix).
+     *
+     * Helper for code paths that don't have direct access to $wpdb,
+     * such as the uninstall.php file.
+     */
+    public static function table_name(\wpdb $wpdb): string
+    {
+        return $wpdb->prefix . self::TABLE_NAME;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -23,10 +23,10 @@ defined('ABSPATH') || exit;
  */
 final class Plugin
 {
-    public const VERSION         = '1.0.0';
-    public const REST_NAMESPACE  = 'apiki-favorites/v1';
-    public const TABLE_NAME      = 'apiki_favorites';
-    public const TEXT_DOMAIN     = 'apiki-favorites';
+    public const VERSION        = '1.0.0';
+    public const REST_NAMESPACE = 'apiki-favorites/v1';
+    public const TABLE_NAME     = 'apiki_favorites';
+    public const TEXT_DOMAIN    = 'apiki-favorites';
 
     /**
      * Wires the plugin into WordPress.

--- a/src/REST/FavoritesController.php
+++ b/src/REST/FavoritesController.php
@@ -66,7 +66,7 @@ final class FavoritesController extends WP_REST_Controller
                     'permission_callback' => [$this, 'permissions_check'],
                     'args'                => [
                         'post_id' => [
-                            'description'       => __('Post ID to favorite.', Plugin::TEXT_DOMAIN),
+                            'description'       => __('Post ID to favorite.', 'apiki-favorites'),
                             'type'              => 'integer',
                             'required'          => true,
                             'minimum'           => 1,
@@ -84,7 +84,7 @@ final class FavoritesController extends WP_REST_Controller
             [
                 'args' => [
                     'post_id' => [
-                        'description'       => __('Post ID to unfavorite.', Plugin::TEXT_DOMAIN),
+                        'description'       => __('Post ID to unfavorite.', 'apiki-favorites'),
                         'type'              => 'integer',
                         'required'          => true,
                         'sanitize_callback' => 'absint',
@@ -116,18 +116,18 @@ final class FavoritesController extends WP_REST_Controller
      */
     public function permissions_check(WP_REST_Request $request): bool|WP_Error
     {
-        if (!is_user_logged_in()) {
+        if ( ! is_user_logged_in()) {
             return new WP_Error(
                 'rest_forbidden_context',
-                __('You must be logged in to manage favorites.', Plugin::TEXT_DOMAIN),
+                __('You must be logged in to manage favorites.', 'apiki-favorites'),
                 ['status' => 401]
             );
         }
 
-        if (!current_user_can('read')) {
+        if ( ! current_user_can('read')) {
             return new WP_Error(
                 'rest_forbidden',
-                __('You are not allowed to manage favorites.', Plugin::TEXT_DOMAIN),
+                __('You are not allowed to manage favorites.', 'apiki-favorites'),
                 ['status' => 403]
             );
         }
@@ -159,7 +159,7 @@ final class FavoritesController extends WP_REST_Controller
         $response->header('X-WP-Total', (string) $total);
         $response->header(
             'X-WP-TotalPages',
-            (string) ($per_page > 0 ? (int) ceil($total / $per_page) : 0)
+            (string) ( $per_page > 0 ? (int) ceil($total / $per_page) : 0 )
         );
 
         return $response;
@@ -175,10 +175,10 @@ final class FavoritesController extends WP_REST_Controller
         $user_id = get_current_user_id();
         $post_id = (int) $request->get_param('post_id');
 
-        if (!$this->post_is_favoritable($post_id)) {
+        if ( ! $this->post_is_favoritable($post_id)) {
             return new WP_Error(
                 'rest_post_invalid',
-                __('Post does not exist or is not published.', Plugin::TEXT_DOMAIN),
+                __('Post does not exist or is not published.', 'apiki-favorites'),
                 ['status' => 404]
             );
         }
@@ -189,7 +189,7 @@ final class FavoritesController extends WP_REST_Controller
             return new WP_Error(
                 'rest_already_favorited',
                 $e->getMessage(),
-                ['status' => $e->getCode() ?: 409]
+                ['status' => $e->getCode() > 0 ? $e->getCode() : 409]
             );
         }
 
@@ -215,7 +215,7 @@ final class FavoritesController extends WP_REST_Controller
             return new WP_Error(
                 'rest_favorite_not_found',
                 $e->getMessage(),
-                ['status' => $e->getCode() ?: 404]
+                ['status' => $e->getCode() > 0 ? $e->getCode() : 404]
             );
         }
 
@@ -248,25 +248,25 @@ final class FavoritesController extends WP_REST_Controller
             'type'       => 'object',
             'properties' => [
                 'id' => [
-                    'description' => __('Unique favorite identifier.', Plugin::TEXT_DOMAIN),
+                    'description' => __('Unique favorite identifier.', 'apiki-favorites'),
                     'type'        => 'integer',
                     'context'     => ['view'],
                     'readonly'    => true,
                 ],
                 'user_id' => [
-                    'description' => __('User who favorited the post.', Plugin::TEXT_DOMAIN),
+                    'description' => __('User who favorited the post.', 'apiki-favorites'),
                     'type'        => 'integer',
                     'context'     => ['view'],
                     'readonly'    => true,
                 ],
                 'post_id' => [
-                    'description' => __('Favorited post ID.', Plugin::TEXT_DOMAIN),
+                    'description' => __('Favorited post ID.', 'apiki-favorites'),
                     'type'        => 'integer',
                     'context'     => ['view'],
                     'required'    => true,
                 ],
                 'created_at' => [
-                    'description' => __('When the favorite was created (UTC).', Plugin::TEXT_DOMAIN),
+                    'description' => __('When the favorite was created (UTC).', 'apiki-favorites'),
                     'type'        => 'string',
                     'format'      => 'date-time',
                     'context'     => ['view'],
@@ -285,14 +285,14 @@ final class FavoritesController extends WP_REST_Controller
     {
         return [
             'page' => [
-                'description'       => __('Current page of results.', Plugin::TEXT_DOMAIN),
+                'description'       => __('Current page of results.', 'apiki-favorites'),
                 'type'              => 'integer',
                 'default'           => 1,
                 'minimum'           => 1,
                 'sanitize_callback' => 'absint',
             ],
             'per_page' => [
-                'description'       => __('Items per page.', Plugin::TEXT_DOMAIN),
+                'description'       => __('Items per page.', 'apiki-favorites'),
                 'type'              => 'integer',
                 'default'           => 10,
                 'minimum'           => 1,

--- a/src/REST/FavoritesController.php
+++ b/src/REST/FavoritesController.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites\REST;
+
+use Apiki\Favorites\Domain\Favorite;
+use Apiki\Favorites\Domain\FavoriteException;
+use Apiki\Favorites\Plugin;
+use Apiki\Favorites\Repository\FavoritesRepository;
+use WP_Error;
+use WP_Post;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined('ABSPATH') || exit;
+
+/**
+ * REST controller for favorites.
+ *
+ * Extends WP_REST_Controller to inherit schema/sanitization/response
+ * helpers — instead of calling register_rest_route() with raw arrays
+ * everywhere.
+ *
+ * Two important conventions enforced here:
+ *
+ *   1. HTTP methods are referenced via WP_REST_Server constants
+ *      (READABLE, CREATABLE, DELETABLE) — never as raw strings like 'GET'
+ *      or 'POST'. The constants are bitmask-friendly, documented, and
+ *      survive refactors in the WP core.
+ *
+ *   2. Authorization uses `current_user_can()` with a capability —
+ *      not bare `is_user_logged_in()`. A login check alone says
+ *      "is there a user?". A capability check says "is the user allowed
+ *      to do THIS thing?". Even when the capability used here ('read')
+ *      is granted to every logged-in role, going through the capability
+ *      system means an admin can later restrict it via a role plugin
+ *      without our code changing.
+ */
+final class FavoritesController extends WP_REST_Controller
+{
+    public function __construct(
+        private readonly FavoritesRepository $repository
+    ) {
+        $this->namespace = Plugin::REST_NAMESPACE;
+        $this->rest_base = 'favorites';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                    'args'                => $this->get_collection_params(),
+                ],
+                [
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => [$this, 'create_item'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                    'args'                => [
+                        'post_id' => [
+                            'description'       => __('Post ID to favorite.', Plugin::TEXT_DOMAIN),
+                            'type'              => 'integer',
+                            'required'          => true,
+                            'minimum'           => 1,
+                            'sanitize_callback' => 'absint',
+                        ],
+                    ],
+                ],
+                'schema' => [$this, 'get_public_item_schema'],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<post_id>\d+)',
+            [
+                'args' => [
+                    'post_id' => [
+                        'description'       => __('Post ID to unfavorite.', Plugin::TEXT_DOMAIN),
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => [$this, 'delete_item'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Authorization gate for every endpoint.
+     *
+     * Two checks, in order:
+     *
+     *   1. is_user_logged_in() — gives a clear 401 vs 403 distinction.
+     *      Without a user, we return 401 Unauthorized (you need to log in).
+     *
+     *   2. current_user_can('read') — capability check. 'read' is the
+     *      capability granted to the lowest WP role (Subscriber), so
+     *      every logged-in user passes by default. The point is NOT to
+     *      restrict access — the point is to route the authorization
+     *      through the capability system so it can be customized later
+     *      without touching this code.
+     */
+    public function permissions_check(WP_REST_Request $request): bool|WP_Error
+    {
+        if (!is_user_logged_in()) {
+            return new WP_Error(
+                'rest_forbidden_context',
+                __('You must be logged in to manage favorites.', Plugin::TEXT_DOMAIN),
+                ['status' => 401]
+            );
+        }
+
+        if (!current_user_can('read')) {
+            return new WP_Error(
+                'rest_forbidden',
+                __('You are not allowed to manage favorites.', Plugin::TEXT_DOMAIN),
+                ['status' => 403]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * GET /favorites — list current user's favorites, paginated.
+     *
+     * @param WP_REST_Request<array<string, mixed>> $request
+     */
+    public function get_items($request): WP_REST_Response
+    {
+        $user_id  = get_current_user_id();
+        $page     = (int) $request->get_param('page');
+        $per_page = (int) $request->get_param('per_page');
+
+        $favorites = $this->repository->list_for_user($user_id, $page, $per_page);
+        $total     = $this->repository->count_for_user($user_id);
+
+        $items = [];
+        foreach ($favorites as $favorite) {
+            $item    = $this->prepare_item_for_response($favorite, $request);
+            $items[] = $this->prepare_response_for_collection($item);
+        }
+
+        $response = rest_ensure_response($items);
+        $response->header('X-WP-Total', (string) $total);
+        $response->header(
+            'X-WP-TotalPages',
+            (string) ($per_page > 0 ? (int) ceil($total / $per_page) : 0)
+        );
+
+        return $response;
+    }
+
+    /**
+     * POST /favorites — favorite a post for the current user.
+     *
+     * @param WP_REST_Request<array<string, mixed>> $request
+     */
+    public function create_item($request): WP_REST_Response|WP_Error
+    {
+        $user_id = get_current_user_id();
+        $post_id = (int) $request->get_param('post_id');
+
+        if (!$this->post_is_favoritable($post_id)) {
+            return new WP_Error(
+                'rest_post_invalid',
+                __('Post does not exist or is not published.', Plugin::TEXT_DOMAIN),
+                ['status' => 404]
+            );
+        }
+
+        try {
+            $favorite = $this->repository->add($user_id, $post_id);
+        } catch (FavoriteException $e) {
+            return new WP_Error(
+                'rest_already_favorited',
+                $e->getMessage(),
+                ['status' => $e->getCode() ?: 409]
+            );
+        }
+
+        $response = $this->prepare_item_for_response($favorite, $request);
+        $response->set_status(201);
+
+        return $response;
+    }
+
+    /**
+     * DELETE /favorites/{post_id} — unfavorite a post.
+     *
+     * @param WP_REST_Request<array<string, mixed>> $request
+     */
+    public function delete_item($request): WP_REST_Response|WP_Error
+    {
+        $user_id = get_current_user_id();
+        $post_id = (int) $request->get_param('post_id');
+
+        try {
+            $this->repository->remove($user_id, $post_id);
+        } catch (FavoriteException $e) {
+            return new WP_Error(
+                'rest_favorite_not_found',
+                $e->getMessage(),
+                ['status' => $e->getCode() ?: 404]
+            );
+        }
+
+        return new WP_REST_Response(null, 204);
+    }
+
+    /**
+     * Converts a Favorite VO into an HTTP response body.
+     *
+     * @param Favorite                              $item
+     * @param WP_REST_Request<array<string, mixed>> $request
+     */
+    public function prepare_item_for_response($item, $request): WP_REST_Response
+    {
+        return rest_ensure_response($item->to_array());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_item_schema(): array
+    {
+        if ($this->schema !== null) {
+            return $this->add_additional_fields_schema($this->schema);
+        }
+
+        $this->schema = [
+            '$schema'    => 'http://json-schema.org/draft-04/schema#',
+            'title'      => 'favorite',
+            'type'       => 'object',
+            'properties' => [
+                'id' => [
+                    'description' => __('Unique favorite identifier.', Plugin::TEXT_DOMAIN),
+                    'type'        => 'integer',
+                    'context'     => ['view'],
+                    'readonly'    => true,
+                ],
+                'user_id' => [
+                    'description' => __('User who favorited the post.', Plugin::TEXT_DOMAIN),
+                    'type'        => 'integer',
+                    'context'     => ['view'],
+                    'readonly'    => true,
+                ],
+                'post_id' => [
+                    'description' => __('Favorited post ID.', Plugin::TEXT_DOMAIN),
+                    'type'        => 'integer',
+                    'context'     => ['view'],
+                    'required'    => true,
+                ],
+                'created_at' => [
+                    'description' => __('When the favorite was created (UTC).', Plugin::TEXT_DOMAIN),
+                    'type'        => 'string',
+                    'format'      => 'date-time',
+                    'context'     => ['view'],
+                    'readonly'    => true,
+                ],
+            ],
+        ];
+
+        return $this->add_additional_fields_schema($this->schema);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_collection_params(): array
+    {
+        return [
+            'page' => [
+                'description'       => __('Current page of results.', Plugin::TEXT_DOMAIN),
+                'type'              => 'integer',
+                'default'           => 1,
+                'minimum'           => 1,
+                'sanitize_callback' => 'absint',
+            ],
+            'per_page' => [
+                'description'       => __('Items per page.', Plugin::TEXT_DOMAIN),
+                'type'              => 'integer',
+                'default'           => 10,
+                'minimum'           => 1,
+                'maximum'           => 100,
+                'sanitize_callback' => 'absint',
+            ],
+        ];
+    }
+
+    /**
+     * Checks that a post exists and is published.
+     *
+     * Private helper kept inside the controller because it bridges the
+     * REST layer (where post existence becomes a 404) and the WP
+     * post API. The repository should not know about WP_Post.
+     */
+    private function post_is_favoritable(int $post_id): bool
+    {
+        $post = get_post($post_id);
+        return $post instanceof WP_Post && $post->post_status === 'publish';
+    }
+}

--- a/src/Repository/FavoritesRepository.php
+++ b/src/Repository/FavoritesRepository.php
@@ -30,6 +30,8 @@ defined('ABSPATH') || exit;
  * same reasons: explicit > implicit, and prefixes are decided by the
  * composition root.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are log text, not HTML output.
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The SQL is built via \$wpdb->prepare() into a local variable, which the sniffer cannot trace.
 final class FavoritesRepository
 {
     public function __construct(
@@ -44,6 +46,9 @@ final class FavoritesRepository
      * The pre-check is convenience for a clean 409 error message. The
      * real protection against duplicates is the UNIQUE INDEX on
      * (user_id, post_id) at the DB level — defense in depth.
+     *
+     * @throws FavoriteException If the favorite already exists.
+     * @throws \RuntimeException If the database insert fails.
      */
     public function add(int $user_id, int $post_id): Favorite
     {
@@ -79,6 +84,9 @@ final class FavoritesRepository
 
     /**
      * Removes a favorite. Throws if it doesn't exist.
+     *
+     * @throws FavoriteException If the favorite does not exist.
+     * @throws \RuntimeException If the database delete fails.
      */
     public function remove(int $user_id, int $post_id): void
     {
@@ -131,7 +139,7 @@ final class FavoritesRepository
      */
     public function list_for_user(int $user_id, int $page, int $per_page): array
     {
-        $offset = max(0, ($page - 1) * $per_page);
+        $offset = max(0, ( $page - 1 ) * $per_page);
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         $sql = $this->wpdb->prepare(
@@ -143,7 +151,11 @@ final class FavoritesRepository
             $per_page,
             $offset
         );
-        $rows = $this->wpdb->get_results($sql) ?: [];
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is built via $wpdb->prepare() above.
+        $rows = $this->wpdb->get_results($sql);
+        if ( ! is_array($rows)) {
+            $rows = [];
+        }
         // phpcs:enable
 
         return array_map(
@@ -164,6 +176,7 @@ final class FavoritesRepository
         );
         // phpcs:enable
 
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is built via $wpdb->prepare() above.
         return (int) $this->wpdb->get_var($sql);
     }
 }

--- a/src/Repository/FavoritesRepository.php
+++ b/src/Repository/FavoritesRepository.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiki\Favorites\Repository;
+
+use Apiki\Favorites\Domain\Favorite;
+use Apiki\Favorites\Domain\FavoriteException;
+use wpdb;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Persistence layer for favorites.
+ *
+ * IMPORTANT DESIGN NOTE
+ * ---------------------
+ * This class deliberately AVOIDS calling `global $wpdb` inside its methods.
+ * `wpdb` is injected exactly once via the constructor and stored as a
+ * readonly property. Reasons:
+ *
+ *   1. Testability — we can pass a mock/fake wpdb in unit tests without
+ *      touching the global scope.
+ *   2. Single source of truth — the database handle is captured once;
+ *      every method uses the same instance.
+ *   3. Honesty — the constructor signature truthfully declares "I need
+ *      a wpdb to work". Hidden globals lie about dependencies.
+ *
+ * The table name is also injected, not built inside each method, for the
+ * same reasons: explicit > implicit, and prefixes are decided by the
+ * composition root.
+ */
+final class FavoritesRepository
+{
+    public function __construct(
+        private readonly wpdb $wpdb,
+        private readonly string $table,
+    ) {
+    }
+
+    /**
+     * Adds a favorite. Throws if it already exists.
+     *
+     * The pre-check is convenience for a clean 409 error message. The
+     * real protection against duplicates is the UNIQUE INDEX on
+     * (user_id, post_id) at the DB level — defense in depth.
+     */
+    public function add(int $user_id, int $post_id): Favorite
+    {
+        if ($this->find($user_id, $post_id) !== null) {
+            throw FavoriteException::already_exists($user_id, $post_id);
+        }
+
+        $created_at = current_time('mysql', true);
+
+        $inserted = $this->wpdb->insert(
+            $this->table,
+            [
+                'user_id'    => $user_id,
+                'post_id'    => $post_id,
+                'created_at' => $created_at,
+            ],
+            ['%d', '%d', '%s']
+        );
+
+        if ($inserted === false) {
+            throw new \RuntimeException(
+                'Failed to insert favorite: ' . $this->wpdb->last_error
+            );
+        }
+
+        return new Favorite(
+            (int) $this->wpdb->insert_id,
+            $user_id,
+            $post_id,
+            $created_at
+        );
+    }
+
+    /**
+     * Removes a favorite. Throws if it doesn't exist.
+     */
+    public function remove(int $user_id, int $post_id): void
+    {
+        $deleted = $this->wpdb->delete(
+            $this->table,
+            [
+                'user_id' => $user_id,
+                'post_id' => $post_id,
+            ],
+            ['%d', '%d']
+        );
+
+        if ($deleted === false) {
+            throw new \RuntimeException(
+                'Failed to delete favorite: ' . $this->wpdb->last_error
+            );
+        }
+
+        if ($deleted === 0) {
+            throw FavoriteException::not_found($user_id, $post_id);
+        }
+    }
+
+    /**
+     * Returns a single favorite, or null if absent.
+     */
+    public function find(int $user_id, int $post_id): ?Favorite
+    {
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $sql = $this->wpdb->prepare(
+            "SELECT id, user_id, post_id, created_at FROM {$this->table}
+             WHERE user_id = %d AND post_id = %d LIMIT 1",
+            $user_id,
+            $post_id
+        );
+        $row = $this->wpdb->get_row($sql);
+        // phpcs:enable
+
+        if ($row === null) {
+            return null;
+        }
+
+        return Favorite::from_row($row);
+    }
+
+    /**
+     * Returns the user's favorites, most recent first.
+     *
+     * @return list<Favorite>
+     */
+    public function list_for_user(int $user_id, int $page, int $per_page): array
+    {
+        $offset = max(0, ($page - 1) * $per_page);
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $sql = $this->wpdb->prepare(
+            "SELECT id, user_id, post_id, created_at FROM {$this->table}
+             WHERE user_id = %d
+             ORDER BY created_at DESC, id DESC
+             LIMIT %d OFFSET %d",
+            $user_id,
+            $per_page,
+            $offset
+        );
+        $rows = $this->wpdb->get_results($sql) ?: [];
+        // phpcs:enable
+
+        return array_map(
+            static fn ($row): Favorite => Favorite::from_row($row),
+            $rows
+        );
+    }
+
+    /**
+     * Counts the user's favorites — used for pagination headers.
+     */
+    public function count_for_user(int $user_id): int
+    {
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $sql = $this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table} WHERE user_id = %d",
+            $user_id
+        );
+        // phpcs:enable
+
+        return (int) $this->wpdb->get_var($sql);
+    }
+}

--- a/src/Repository/FavoritesRepository.php
+++ b/src/Repository/FavoritesRepository.php
@@ -69,6 +69,10 @@ final class FavoritesRepository
         );
 
         if ($inserted === false) {
+            if (stripos($this->wpdb->last_error, 'duplicate') !== false) {
+                throw FavoriteException::already_exists($user_id, $post_id);
+            }
+
             throw new \RuntimeException(
                 'Failed to insert favorite: ' . $this->wpdb->last_error
             );

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,5 +22,5 @@ $table = $wpdb->prefix . 'apiki_favorites';
 // runs in a minimal bootstrap context). The literal table name is
 // duplicated here on purpose; if Plugin::TABLE_NAME ever changes, this
 // constant must change alongside it.
-// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- DROP TABLE is exactly what uninstall should do; caching/preparing does not apply.
 $wpdb->query("DROP TABLE IF EXISTS {$table}");

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Uninstall handler.
+ *
+ * WordPress calls this file when the user clicks "Delete" on the plugin
+ * from the plugins page — NOT on simple deactivation. That distinction is
+ * intentional: deactivating shouldn't wipe data, only uninstalling should.
+ *
+ * @package Apiki\Favorites
+ */
+
+declare(strict_types=1);
+
+defined('WP_UNINSTALL_PLUGIN') || exit;
+
+global $wpdb;
+
+$table = $wpdb->prefix . 'apiki_favorites';
+
+// We can't load the plugin autoloader from here reliably (uninstall.php
+// runs in a minimal bootstrap context). The literal table name is
+// duplicated here on purpose; if Plugin::TABLE_NAME ever changes, this
+// constant must change alongside it.
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query("DROP TABLE IF EXISTS {$table}");


### PR DESCRIPTION
## Resumo

Plugin WordPress que permite a usuários logados favoritar e desfavoritar posts via WP REST API, com persistência em tabela própria.

## Endpoints

Todos sob `/wp-json/apiki-favorites/v1`:

- `GET /favorites?page=1&per_page=10` — lista paginada dos favoritos do usuário atual (200)
- `POST /favorites` com body `{"post_id": N}` — favorita um post (201; 409 se duplicado; 404 se post não existe)
- `DELETE /favorites/{post_id}` — remove (204; 404 se não existe)

Sem autenticação retorna 401.

## Como rodar localmente (Docker)

Sobe os containers com `docker compose up -d`. Acessa `http://localhost:8080` e finaliza o setup do WordPress. Em **Plugins**, ativa o "Apiki Favorites". Em **Configurações → Links permanentes**, escolhe "Nome do post". Cria um Application Password no perfil do usuário e testa com `curl` ou Postman.

Pra rodar o lint WPCS: `docker compose run --rm cli install` seguido de `docker compose run --rm cli lint`.

## Test plan (validação manual)

- [x] Plugin ativa sem erros e cria a tabela `wp_apiki_favorites`
- [x] `POST /favorites` retorna 201 com `{id, user_id, post_id, created_at}`
- [x] `GET /favorites` retorna 200 com array de favoritos e headers `X-WP-Total` / `X-WP-TotalPages`
- [x] `POST` duplicado retorna 409 `rest_already_favorited`
- [x] `POST` com post inexistente retorna 404 `rest_post_invalid`
- [x] `DELETE /favorites/{id}` retorna 204 sem body
- [x] Requisição sem autenticação retorna 401 `rest_forbidden_context`
- [x] Lint WPCS passa limpo (0 erros, 0 warnings)

## Decisões de design

Documentadas em detalhe no `README.md`.